### PR TITLE
Added errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "require": {
         "guzzlehttp/guzzle": "6.*||7.*",
         "monolog/monolog": "1.*||2.*",
-        "nesbot/carbon": "1.*||2.*",
         "psr/log": "1.*",
         "ramsey/uuid": "^3.9||^4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a35eb153ef8ffe651b41d8ae6cb4743e",
+    "content-hash": "0d5e3a5adbc34339b11cdeef752635d2",
     "packages": [
         {
             "name": "brick/math",
@@ -392,99 +392,6 @@
             "time": "2020-12-14T13:15:25+00:00"
         },
         {
-            "name": "nesbot/carbon",
-            "version": "2.48.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "d3c447f21072766cddec3522f9468a5849a76147"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/d3c447f21072766cddec3522f9468a5849a76147",
-                "reference": "d3c447f21072766cddec3522f9468a5849a76147",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": "^7.1.8 || ^8.0",
-                "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation": "^3.4 || ^4.0 || ^5.0"
-            },
-            "require-dev": {
-                "doctrine/orm": "^2.7",
-                "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
-                "kylekatarnls/multi-tester": "^2.0",
-                "phpmd/phpmd": "^2.9",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.54",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.14",
-                "squizlabs/php_codesniffer": "^3.4"
-            },
-            "bin": [
-                "bin/carbon"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev",
-                    "dev-3.x": "3.x-dev"
-                },
-                "laravel": {
-                    "providers": [
-                        "Carbon\\Laravel\\ServiceProvider"
-                    ]
-                },
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Carbon\\": "src/Carbon/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brian Nesbitt",
-                    "email": "brian@nesbot.com",
-                    "homepage": "http://nesbot.com"
-                },
-                {
-                    "name": "kylekatarnls",
-                    "homepage": "http://github.com/kylekatarnls"
-                }
-            ],
-            "description": "An API extension for DateTime that supports 281 different languages.",
-            "homepage": "http://carbon.nesbot.com",
-            "keywords": [
-                "date",
-                "datetime",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/briannesbitt/Carbon/issues",
-                "source": "https://github.com/briannesbitt/Carbon"
-            },
-            "funding": [
-                {
-                    "url": "https://opencollective.com/Carbon",
-                    "type": "open_collective"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-05-07T10:08:30+00:00"
-        },
-        {
             "name": "psr/http-client",
             "version": "1.0.1",
             "source": {
@@ -854,16 +761,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -875,7 +782,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -913,7 +820,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -929,341 +836,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.22-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-01-22T09:19:47+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.22-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-01-07T16:49:33+00:00"
-        },
-        {
-            "name": "symfony/translation",
-            "version": "v5.2.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "445caa74a5986f1cc9dd91a2975ef68fa7cb2068"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/445caa74a5986f1cc9dd91a2975ef68fa7cb2068",
-                "reference": "445caa74a5986f1cc9dd91a2975ef68fa7cb2068",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.15",
-                "symfony/translation-contracts": "^2.3"
-            },
-            "conflict": {
-                "symfony/config": "<4.4",
-                "symfony/dependency-injection": "<5.0",
-                "symfony/http-kernel": "<5.0",
-                "symfony/twig-bundle": "<5.0",
-                "symfony/yaml": "<4.4"
-            },
-            "provide": {
-                "symfony/translation-implementation": "2.3"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/console": "^4.4|^5.0",
-                "symfony/dependency-injection": "^5.0",
-                "symfony/finder": "^4.4|^5.0",
-                "symfony/http-kernel": "^5.0",
-                "symfony/intl": "^4.4|^5.0",
-                "symfony/service-contracts": "^1.1.2|^2",
-                "symfony/yaml": "^4.4|^5.0"
-            },
-            "suggest": {
-                "psr/log-implementation": "To use logging capability in translator",
-                "symfony/config": "",
-                "symfony/yaml": ""
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\Translation\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools to internationalize your application",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.2.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-05-07T13:41:16+00:00"
-        },
-        {
-            "name": "symfony/translation-contracts",
-            "version": "v2.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "95c812666f3e91db75385749fe219c5e494c7f95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/95c812666f3e91db75385749fe219c5e494c7f95",
-                "reference": "95c812666f3e91db75385749fe219c5e494c7f95",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5"
-            },
-            "suggest": {
-                "symfony/translation-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Translation\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to translation",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v2.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-03-23T23:28:01+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         }
     ],
     "packages-dev": [
@@ -1824,16 +1397,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v8.41.0",
+            "version": "v8.48.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "05417155d886df8710e55c84e12622b52d83c47c"
+                "reference": "edc138060a13c9e5f15c005fad5f6a39b4ccf5fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/05417155d886df8710e55c84e12622b52d83c47c",
-                "reference": "05417155d886df8710e55c84e12622b52d83c47c",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/edc138060a13c9e5f15c005fad5f6a39b4ccf5fa",
+                "reference": "edc138060a13c9e5f15c005fad5f6a39b4ccf5fa",
                 "shasum": ""
             },
             "require": {
@@ -1912,10 +1485,10 @@
                 "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
                 "league/flysystem-cached-adapter": "^1.0",
                 "mockery/mockery": "^1.4.2",
-                "orchestra/testbench-core": "^6.8",
+                "orchestra/testbench-core": "^6.23",
                 "pda/pheanstalk": "^4.0",
                 "phpunit/phpunit": "^8.5.8|^9.3.3",
-                "predis/predis": "^1.1.1",
+                "predis/predis": "^1.1.2",
                 "symfony/cache": "^5.1.4"
             },
             "suggest": {
@@ -1988,20 +1561,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-05-11T14:00:02+00:00"
+            "time": "2021-06-23T13:41:59+00:00"
         },
         {
             "name": "league/commonmark",
-            "version": "1.6.2",
+            "version": "1.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "7d70d2f19c84bcc16275ea47edabee24747352eb"
+                "reference": "c3c8b7217c52572fb42aaf84211abccf75a151b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/7d70d2f19c84bcc16275ea47edabee24747352eb",
-                "reference": "7d70d2f19c84bcc16275ea47edabee24747352eb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/c3c8b7217c52572fb42aaf84211abccf75a151b2",
+                "reference": "c3c8b7217c52572fb42aaf84211abccf75a151b2",
                 "shasum": ""
             },
             "require": {
@@ -2019,7 +1592,7 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "~1.4",
                 "mikehaertl/php-shellcommand": "^1.4",
-                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan": "^0.12.90",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
                 "scrutinizer/ocular": "^1.5",
                 "symfony/finder": "^4.2"
@@ -2089,20 +1662,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-12T11:39:41+00:00"
+            "time": "2021-06-19T20:08:14+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "9be3b16c877d477357c015cec057548cf9b2a14a"
+                "reference": "f3ad69181b8afed2c9edf7be5a2918144ff4ea32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/9be3b16c877d477357c015cec057548cf9b2a14a",
-                "reference": "9be3b16c877d477357c015cec057548cf9b2a14a",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f3ad69181b8afed2c9edf7be5a2918144ff4ea32",
+                "reference": "f3ad69181b8afed2c9edf7be5a2918144ff4ea32",
                 "shasum": ""
             },
             "require": {
@@ -2118,7 +1691,6 @@
                 "phpunit/phpunit": "^8.5.8"
             },
             "suggest": {
-                "ext-fileinfo": "Required for MimeType",
                 "ext-ftp": "Allows you to use FTP server storage",
                 "ext-openssl": "Allows you to use FTPS server storage",
                 "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
@@ -2176,7 +1748,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.x"
+                "source": "https://github.com/thephpleague/flysystem/tree/1.1.4"
             },
             "funding": [
                 {
@@ -2184,7 +1756,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2020-08-23T07:39:11+00:00"
+            "time": "2021-06-23T21:56:05+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -2373,6 +1945,99 @@
             "time": "2020-11-13T09:40:50+00:00"
         },
         {
+            "name": "nesbot/carbon",
+            "version": "2.49.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/briannesbitt/Carbon.git",
+                "reference": "93d9db91c0235c486875d22f1e08b50bdf3e6eee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/93d9db91c0235c486875d22f1e08b50bdf3e6eee",
+                "reference": "93d9db91c0235c486875d22f1e08b50bdf3e6eee",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.1.8 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation": "^3.4 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "doctrine/orm": "^2.7",
+                "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
+                "kylekatarnls/multi-tester": "^2.0",
+                "phpmd/phpmd": "^2.9",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.54",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.14",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "bin": [
+                "bin/carbon"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-3.x": "3.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Carbon\\Laravel\\ServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "http://nesbot.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "http://github.com/kylekatarnls"
+                }
+            ],
+            "description": "An API extension for DateTime that supports 281 different languages.",
+            "homepage": "http://carbon.nesbot.com",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/briannesbitt/Carbon/issues",
+                "source": "https://github.com/briannesbitt/Carbon"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-02T07:31:40+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.10.5",
             "source": {
@@ -2495,25 +2160,25 @@
         },
         {
             "name": "orchestra/testbench",
-            "version": "v6.17.0",
+            "version": "v6.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "1782d7d54312ebbf3bf79d66e4ac46e7dee78e0f"
+                "reference": "022e72b16f56a35254c343e57a306564d20d85b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/1782d7d54312ebbf3bf79d66e4ac46e7dee78e0f",
-                "reference": "1782d7d54312ebbf3bf79d66e4ac46e7dee78e0f",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/022e72b16f56a35254c343e57a306564d20d85b2",
+                "reference": "022e72b16f56a35254c343e57a306564d20d85b2",
                 "shasum": ""
             },
             "require": {
                 "laravel/framework": "^8.25",
                 "mockery/mockery": "^1.4.2",
-                "orchestra/testbench-core": "^6.21",
+                "orchestra/testbench-core": "^6.22",
                 "php": "^7.3 || ^8.0",
                 "phpunit/phpunit": "^8.4 || ^9.3.3",
-                "spatie/laravel-ray": "^1.17.1"
+                "spatie/laravel-ray": "^1.18"
             },
             "type": "library",
             "extra": {
@@ -2544,7 +2209,7 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/v6.17.0"
+                "source": "https://github.com/orchestral/testbench/tree/v6.18.0"
             },
             "funding": [
                 {
@@ -2556,20 +2221,20 @@
                     "type": "liberapay"
                 }
             ],
-            "time": "2021-04-06T12:07:42+00:00"
+            "time": "2021-05-25T04:04:31+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v6.21.2",
+            "version": "v6.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "6b536a0f18227a156762e074f12bb17547eaf4f4"
+                "reference": "6d88802eb6010ab845ec8b3a07895148262297f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/6b536a0f18227a156762e074f12bb17547eaf4f4",
-                "reference": "6b536a0f18227a156762e074f12bb17547eaf4f4",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/6d88802eb6010ab845ec8b3a07895148262297f3",
+                "reference": "6d88802eb6010ab845ec8b3a07895148262297f3",
                 "shasum": ""
             },
             "require": {
@@ -2643,7 +2308,7 @@
                     "type": "liberapay"
                 }
             ],
-            "time": "2021-05-11T20:58:20+00:00"
+            "time": "2021-06-15T22:53:33+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3370,16 +3035,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.4",
+            "version": "9.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741"
+                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c73c6737305e779771147af66c96ca6a7ed8a741",
-                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
+                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
                 "shasum": ""
             },
             "require": {
@@ -3409,7 +3074,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -3457,7 +3122,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.6"
             },
             "funding": [
                 {
@@ -3469,7 +3134,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-23T07:16:29+00:00"
+            "time": "2021-06-23T05:14:38+00:00"
         },
         {
             "name": "psr/container",
@@ -4126,16 +3791,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -4178,7 +3843,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -4186,7 +3851,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4477,16 +4142,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
@@ -4521,7 +4186,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -4529,7 +4194,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4586,16 +4251,16 @@
         },
         {
             "name": "spatie/backtrace",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/backtrace.git",
-                "reference": "3440fe023a7d5b4497090fb6b2dcdc747daf7873"
+                "reference": "9b4df807fb65aaa8006dcd7a7ccdef8fb4bb002e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/backtrace/zipball/3440fe023a7d5b4497090fb6b2dcdc747daf7873",
-                "reference": "3440fe023a7d5b4497090fb6b2dcdc747daf7873",
+                "url": "https://api.github.com/repos/spatie/backtrace/zipball/9b4df807fb65aaa8006dcd7a7ccdef8fb4bb002e",
+                "reference": "9b4df807fb65aaa8006dcd7a7ccdef8fb4bb002e",
                 "shasum": ""
             },
             "require": {
@@ -4632,7 +4297,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/backtrace/issues",
-                "source": "https://github.com/spatie/backtrace/tree/1.1.0"
+                "source": "https://github.com/spatie/backtrace/tree/1.2.0"
             },
             "funding": [
                 {
@@ -4644,36 +4309,37 @@
                     "type": "other"
                 }
             ],
-            "time": "2021-01-29T09:20:43+00:00"
+            "time": "2021-05-19T12:49:10+00:00"
         },
         {
             "name": "spatie/laravel-ray",
-            "version": "1.17.4",
+            "version": "1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-ray.git",
-                "reference": "e48be16da1952ffca868c77f509a767d3fc632bc"
+                "reference": "2e49e83f3df25e4ef7a145cb0247d2038b8d3436"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-ray/zipball/e48be16da1952ffca868c77f509a767d3fc632bc",
-                "reference": "e48be16da1952ffca868c77f509a767d3fc632bc",
+                "url": "https://api.github.com/repos/spatie/laravel-ray/zipball/2e49e83f3df25e4ef7a145cb0247d2038b8d3436",
+                "reference": "2e49e83f3df25e4ef7a145cb0247d2038b8d3436",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "illuminate/contracts": "^7.20|^8.0",
-                "illuminate/database": "^7.20|^8.13",
-                "illuminate/queue": "^7.20|^8.13",
-                "illuminate/support": "^7.20|^8.13",
+                "illuminate/contracts": "^7.20|^8.19",
+                "illuminate/database": "^7.20|^8.19",
+                "illuminate/queue": "^7.20|^8.19",
+                "illuminate/support": "^7.20|^8.19",
                 "php": "^7.3|^8.0",
                 "spatie/backtrace": "^1.0",
-                "spatie/ray": "^1.21.2",
+                "spatie/ray": "^1.27.1",
                 "symfony/stopwatch": "4.2|^5.1",
                 "zbateson/mail-mime-parser": "^1.3.1"
             },
             "require-dev": {
                 "facade/ignition": "^2.5",
+                "guzzlehttp/guzzle": "^7.3",
                 "laravel/framework": "^7.20|^8.19",
                 "orchestra/testbench-core": "^5.0|^6.0",
                 "phpunit/phpunit": "^9.3",
@@ -4712,7 +4378,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-ray/issues",
-                "source": "https://github.com/spatie/laravel-ray/tree/1.17.4"
+                "source": "https://github.com/spatie/laravel-ray/tree/1.23.0"
             },
             "funding": [
                 {
@@ -4724,7 +4390,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2021-04-30T08:20:24+00:00"
+            "time": "2021-06-24T14:47:53+00:00"
         },
         {
             "name": "spatie/macroable",
@@ -4778,16 +4444,16 @@
         },
         {
             "name": "spatie/ray",
-            "version": "1.22.1",
+            "version": "1.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/ray.git",
-                "reference": "e82408b78b1391eaee6c962b13c37e80080dc15a"
+                "reference": "57880fa060c81256363b4b9706e99df447af8613"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/ray/zipball/e82408b78b1391eaee6c962b13c37e80080dc15a",
-                "reference": "e82408b78b1391eaee6c962b13c37e80080dc15a",
+                "url": "https://api.github.com/repos/spatie/ray/zipball/57880fa060c81256363b4b9706e99df447af8613",
+                "reference": "57880fa060c81256363b4b9706e99df447af8613",
                 "shasum": ""
             },
             "require": {
@@ -4837,7 +4503,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/ray/issues",
-                "source": "https://github.com/spatie/ray/tree/1.22.1"
+                "source": "https://github.com/spatie/ray/tree/1.27.1"
             },
             "funding": [
                 {
@@ -4849,7 +4515,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2021-04-28T09:47:47+00:00"
+            "time": "2021-06-24T06:58:50+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4984,20 +4650,21 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.8",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "864568fdc0208b3eba3638b6000b69d2386e6768"
+                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/864568fdc0208b3eba3638b6000b69d2386e6768",
-                "reference": "864568fdc0208b3eba3638b6000b69d2386e6768",
+                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/polyfill-php80": "^1.15",
@@ -5061,7 +4728,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.8"
+                "source": "https://github.com/symfony/console/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -5077,20 +4744,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-11T15:45:21+00:00"
+            "time": "2021-06-12T09:42:48+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.2.7",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "59a684f5ac454f066ecbe6daecce6719aed283fb"
+                "reference": "fcd0b29a7a0b1bb5bfbedc6231583d77fea04814"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/59a684f5ac454f066ecbe6daecce6719aed283fb",
-                "reference": "59a684f5ac454f066ecbe6daecce6719aed283fb",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/fcd0b29a7a0b1bb5bfbedc6231583d77fea04814",
+                "reference": "fcd0b29a7a0b1bb5bfbedc6231583d77fea04814",
                 "shasum": ""
             },
             "require": {
@@ -5126,7 +4793,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.3.0-BETA1"
+                "source": "https://github.com/symfony/css-selector/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5142,7 +4809,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-07T16:07:52+00:00"
+            "time": "2021-05-26T17:40:38+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5213,16 +4880,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v5.2.8",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "1416bc16317a8188aabde251afef7618bf4687ac"
+                "reference": "0e6768b8c0dcef26df087df2bbbaa143867a59b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/1416bc16317a8188aabde251afef7618bf4687ac",
-                "reference": "1416bc16317a8188aabde251afef7618bf4687ac",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/0e6768b8c0dcef26df087df2bbbaa143867a59b2",
+                "reference": "0e6768b8c0dcef26df087df2bbbaa143867a59b2",
                 "shasum": ""
             },
             "require": {
@@ -5262,7 +4929,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v5.2.8"
+                "source": "https://github.com/symfony/error-handler/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5278,20 +4945,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-07T13:42:21+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.2.4",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d08d6ec121a425897951900ab692b612a61d6240"
+                "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d08d6ec121a425897951900ab692b612a61d6240",
-                "reference": "d08d6ec121a425897951900ab692b612a61d6240",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/67a5f354afa8e2f231081b3fa11a5912f933c3ce",
+                "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce",
                 "shasum": ""
             },
             "require": {
@@ -5347,7 +5014,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.4"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5363,7 +5030,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-18T17:12:37+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -5446,16 +5113,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.2.8",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "eccb8be70d7a6a2230d05f6ecede40f3fdd9e252"
+                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/eccb8be70d7a6a2230d05f6ecede40f3fdd9e252",
-                "reference": "eccb8be70d7a6a2230d05f6ecede40f3fdd9e252",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
                 "shasum": ""
             },
             "require": {
@@ -5487,7 +5154,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.8"
+                "source": "https://github.com/symfony/finder/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -5503,7 +5170,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-10T14:39:23+00:00"
+            "time": "2021-05-26T12:52:38+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -5585,16 +5252,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.2.8",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "e8fbbab7c4a71592985019477532629cb2e142dc"
+                "reference": "7b6dd714d95106b831aaa7f3c9c612ab886516bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e8fbbab7c4a71592985019477532629cb2e142dc",
-                "reference": "e8fbbab7c4a71592985019477532629cb2e142dc",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/7b6dd714d95106b831aaa7f3c9c612ab886516bd",
+                "reference": "7b6dd714d95106b831aaa7f3c9c612ab886516bd",
                 "shasum": ""
             },
             "require": {
@@ -5638,7 +5305,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.2.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -5654,20 +5321,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-07T13:41:16+00:00"
+            "time": "2021-06-12T10:15:17+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.2.8",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "c3cb71ee7e2d3eae5fe1001f81780d6a49b37937"
+                "reference": "e7021165d9dbfb4051296b8de827e92c8a7b5c87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c3cb71ee7e2d3eae5fe1001f81780d6a49b37937",
-                "reference": "c3cb71ee7e2d3eae5fe1001f81780d6a49b37937",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e7021165d9dbfb4051296b8de827e92c8a7b5c87",
+                "reference": "e7021165d9dbfb4051296b8de827e92c8a7b5c87",
                 "shasum": ""
             },
             "require": {
@@ -5677,7 +5344,7 @@
                 "symfony/error-handler": "^4.4|^5.0",
                 "symfony/event-dispatcher": "^5.0",
                 "symfony/http-client-contracts": "^1.1|^2",
-                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/http-foundation": "^5.3",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-php73": "^1.9",
                 "symfony/polyfill-php80": "^1.15"
@@ -5687,7 +5354,7 @@
                 "symfony/cache": "<5.0",
                 "symfony/config": "<5.0",
                 "symfony/console": "<4.4",
-                "symfony/dependency-injection": "<5.1.8",
+                "symfony/dependency-injection": "<5.3",
                 "symfony/doctrine-bridge": "<5.0",
                 "symfony/form": "<5.0",
                 "symfony/http-client": "<5.0",
@@ -5707,7 +5374,7 @@
                 "symfony/config": "^5.0",
                 "symfony/console": "^4.4|^5.0",
                 "symfony/css-selector": "^4.4|^5.0",
-                "symfony/dependency-injection": "^5.1.8",
+                "symfony/dependency-injection": "^5.3",
                 "symfony/dom-crawler": "^4.4|^5.0",
                 "symfony/expression-language": "^4.4|^5.0",
                 "symfony/finder": "^4.4|^5.0",
@@ -5750,7 +5417,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.2.8"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -5766,20 +5433,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-12T13:27:53+00:00"
+            "time": "2021-06-17T14:18:27+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v5.2.7",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "7af452bf51c46f18da00feb32e1ad36db9426515"
+                "reference": "47dd7912152b82d0d4c8d9040dbc93d6232d472a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/7af452bf51c46f18da00feb32e1ad36db9426515",
-                "reference": "7af452bf51c46f18da00feb32e1ad36db9426515",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/47dd7912152b82d0d4c8d9040dbc93d6232d472a",
+                "reference": "47dd7912152b82d0d4c8d9040dbc93d6232d472a",
                 "shasum": ""
             },
             "require": {
@@ -5833,7 +5500,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.2.7"
+                "source": "https://github.com/symfony/mime/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -5849,20 +5516,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-29T20:47:09+00:00"
+            "time": "2021-06-09T10:58:01+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342"
+                "reference": "63b5bb7db83e5673936d6e3b8b3e022ff6474933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/06fb361659649bcfd6a208a0f1fcaf4e827ad342",
-                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/63b5bb7db83e5673936d6e3b8b3e022ff6474933",
+                "reference": "63b5bb7db83e5673936d6e3b8b3e022ff6474933",
                 "shasum": ""
             },
             "require": {
@@ -5874,7 +5541,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5913,7 +5580,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -5929,20 +5596,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
                 "shasum": ""
             },
             "require": {
@@ -5954,7 +5621,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5994,7 +5661,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6010,20 +5677,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483"
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/2d63434d922daf7da8dd863e7907e67ee3031483",
-                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
                 "shasum": ""
             },
             "require": {
@@ -6037,7 +5704,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6081,7 +5748,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6097,20 +5764,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
                 "shasum": ""
             },
             "require": {
@@ -6122,7 +5789,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6165,7 +5832,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6181,20 +5848,100 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
-            "name": "symfony/polyfill-php72",
-            "version": "v1.22.1",
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9"
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
                 "shasum": ""
             },
             "require": {
@@ -6203,7 +5950,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6241,7 +5988,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6257,20 +6004,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -6279,7 +6026,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6320,7 +6067,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -6336,20 +6083,103 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v5.2.7",
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e"
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e",
-                "reference": "98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "714b47f9196de61a196d86c4bad5f09201b307df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/714b47f9196de61a196d86c4bad5f09201b307df",
+                "reference": "714b47f9196de61a196d86c4bad5f09201b307df",
                 "shasum": ""
             },
             "require": {
@@ -6382,7 +6212,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.3.0-BETA1"
+                "source": "https://github.com/symfony/process/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -6398,20 +6228,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-08T10:27:02+00:00"
+            "time": "2021-06-12T10:15:01+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v5.2.7",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c"
+                "reference": "368e81376a8e049c37cb80ae87dbfbf411279199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c",
-                "reference": "3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/368e81376a8e049c37cb80ae87dbfbf411279199",
+                "reference": "368e81376a8e049c37cb80ae87dbfbf411279199",
                 "shasum": ""
             },
             "require": {
@@ -6420,14 +6250,15 @@
                 "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
-                "symfony/config": "<5.0",
+                "doctrine/annotations": "<1.12",
+                "symfony/config": "<5.3",
                 "symfony/dependency-injection": "<4.4",
                 "symfony/yaml": "<4.4"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.10.4",
+                "doctrine/annotations": "^1.12",
                 "psr/log": "~1.0",
-                "symfony/config": "^5.0",
+                "symfony/config": "^5.3",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/expression-language": "^4.4|^5.0",
                 "symfony/http-foundation": "^4.4|^5.0",
@@ -6471,7 +6302,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.2.7"
+                "source": "https://github.com/symfony/routing/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -6487,7 +6318,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-11T22:55:21+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6570,16 +6401,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.2.7",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "d99310c33e833def36419c284f60e8027d359678"
+                "reference": "313d02f59d6543311865007e5ff4ace05b35ee65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/d99310c33e833def36419c284f60e8027d359678",
-                "reference": "d99310c33e833def36419c284f60e8027d359678",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/313d02f59d6543311865007e5ff4ace05b35ee65",
+                "reference": "313d02f59d6543311865007e5ff4ace05b35ee65",
                 "shasum": ""
             },
             "require": {
@@ -6612,7 +6443,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.3.0-BETA1"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -6628,20 +6459,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-29T15:28:41+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.8",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db"
+                "reference": "0732e97e41c0a590f77e231afc16a327375d50b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db",
-                "reference": "01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db",
+                "url": "https://api.github.com/repos/symfony/string/zipball/0732e97e41c0a590f77e231afc16a327375d50b0",
+                "reference": "0732e97e41c0a590f77e231afc16a327375d50b0",
                 "shasum": ""
             },
             "require": {
@@ -6695,7 +6526,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.8"
+                "source": "https://github.com/symfony/string/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -6711,20 +6542,193 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-10T14:56:10+00:00"
+            "time": "2021-06-06T09:51:56+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v5.2.8",
+            "name": "symfony/translation",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "d693200a73fae179d27f8f1b16b4faf3e8569eba"
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "7e2603bcc598e14804c4d2359d8dc4ee3c40391b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/d693200a73fae179d27f8f1b16b4faf3e8569eba",
-                "reference": "d693200a73fae179d27f8f1b16b4faf3e8569eba",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/7e2603bcc598e14804c4d2359d8dc4ee3c40391b",
+                "reference": "7e2603bcc598e14804c4d2359d8dc4ee3c40391b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/translation-contracts": "^2.3"
+            },
+            "conflict": {
+                "symfony/config": "<4.4",
+                "symfony/dependency-injection": "<5.0",
+                "symfony/http-kernel": "<5.0",
+                "symfony/twig-bundle": "<5.0",
+                "symfony/yaml": "<4.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/dependency-injection": "^5.0",
+                "symfony/finder": "^4.4|^5.0",
+                "symfony/http-kernel": "^5.0",
+                "symfony/intl": "^4.4|^5.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/service-contracts": "^1.1.2|^2",
+                "symfony/yaml": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log-implementation": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v5.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-06T09:51:56+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "95c812666f3e91db75385749fe219c5e494c7f95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/95c812666f3e91db75385749fe219c5e494c7f95",
+                "reference": "95c812666f3e91db75385749fe219c5e494c7f95",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v5.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "905a22c68b292ffb6f20d7636c36b220d1fba5ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/905a22c68b292ffb6f20d7636c36b220d1fba5ae",
+                "reference": "905a22c68b292ffb6f20d7636c36b220d1fba5ae",
                 "shasum": ""
             },
             "require": {
@@ -6783,7 +6787,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.2.8"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -6799,20 +6803,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-07T13:42:21+00:00"
+            "time": "2021-06-06T09:51:56+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.2.7",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "76546cbeddd0a9540b4e4e57eddeec3e9bb444a5"
+                "reference": "71719ab2409401711d619765aa255f9d352a59b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/76546cbeddd0a9540b4e4e57eddeec3e9bb444a5",
-                "reference": "76546cbeddd0a9540b4e4e57eddeec3e9bb444a5",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/71719ab2409401711d619765aa255f9d352a59b2",
+                "reference": "71719ab2409401711d619765aa255f9d352a59b2",
                 "shasum": ""
             },
             "require": {
@@ -6858,7 +6862,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.2.7"
+                "source": "https://github.com/symfony/yaml/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -6874,7 +6878,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-29T20:47:09+00:00"
+            "time": "2021-06-06T09:51:56+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Client as Guzzle;
 
 class Client
 {
-
+    public const ERRORS_ENDPOINT = 'https://api.tail.dev/ingest/errors';
     public const LOGS_ENDPOINT = 'https://api.tail.dev/ingest/logs';
     public const APM_ENDPOINT = 'https://api.tail.dev/ingest/transactions';
 
@@ -14,6 +14,8 @@ class Client
 
     /** @var Guzzle */
     protected $guzzle;
+
+    protected $errorSendHandlers = [];
 
     protected $logSendHandlers = [];
 
@@ -23,8 +25,13 @@ class Client
     {
         $this->token = $token;
         $this->guzzle = $guzzle ?? new Guzzle();
+        $this->registerDefaultErrorSendHandler();
         $this->registerDefaultLogSendHandler();
         $this->registerDefaultApmSendHandler();
+    }
+    public function registerErrorSendHandler($handler)
+    {
+        $this->errorSendHandlers[] = $handler;
     }
 
     public function registerLogSendHandler($handler)
@@ -35,6 +42,16 @@ class Client
     public function registerApmSendHandler($handler)
     {
         $this->apmSendHandlers[] = $handler;
+    }
+
+    public function sendError(array $error)
+    {
+        $handlers = array_reverse($this->errorSendHandlers);
+        foreach ($handlers as $handler) {
+            if ($handler($error) === false) {
+                return;
+            }
+        }
     }
 
     public function sendLogs(array $logs)
@@ -66,6 +83,20 @@ class Client
     public function token()
     {
         return $this->token;
+    }
+
+    private function registerDefaultErrorSendHandler()
+    {
+        $this->registerErrorSendHandler(function (array $errors) {
+            $url = getenv('TAIL_ERRORS_ENDPOINT') ?: self::ERRORS_ENDPOINT;
+
+            $this->guzzle->post($url, [
+                'json' => $errors,
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->token,
+                ],
+            ]);
+        });
     }
 
     private function registerDefaultLogSendHandler()

--- a/src/Client.php
+++ b/src/Client.php
@@ -44,11 +44,11 @@ class Client
         $this->apmSendHandlers[] = $handler;
     }
 
-    public function sendError(array $error)
+    public function sendErrors(array $errors)
     {
         $handlers = array_reverse($this->errorSendHandlers);
         foreach ($handlers as $handler) {
-            if ($handler($error) === false) {
+            if ($handler($errors) === false) {
                 return;
             }
         }

--- a/src/Error.php
+++ b/src/Error.php
@@ -1,0 +1,37 @@
+<?php
+namespace Tail;
+
+use Tail\Error\Trace;
+use Tail\Meta\Cookies;
+use Tail\Meta\Http;
+
+class Error
+{
+    public static $error;
+
+    /**
+     * Capture the exception
+     */
+    public static function capture($e)
+    {
+        $error = [
+            'exception' => get_class($e),
+            'message' => $e->getMessage(),
+            'code' => $e->getCode(),
+            'file' => $e->getFile(),
+            'line' => $e->getLine(),
+            'runtime' => 'php',
+            'runtime_version' => phpversion(),
+            'time' => gmdate(DATE_ATOM),
+            'http' => (new Http())->toArray(),
+            'cookies' => (new Cookies())->toArray(),
+            'trace' => (new Trace($e->getTrace()))->toArray(),
+        ];
+
+        static::$error = $error;
+
+        if (Tail::errorsEnabled()) {
+            Tail::client()->sendError(static::$error);
+        }
+    }
+}

--- a/src/Error/Trace.php
+++ b/src/Error/Trace.php
@@ -1,0 +1,80 @@
+<?php
+namespace Tail\Error;
+
+class Trace
+{
+    /** @var array Trace of files */
+    protected $trace = [];
+
+    public function __construct(array $trace)
+    {
+        foreach ($trace as $t) {
+            $traceArr = [
+                'file' => isset($t['file']) ? $t['file'] : '',
+                'line' => isset($t['line']) ? $t['line'] : '',
+                'function' => isset($t['function']) ? $t['function'] : '',
+                'class' => isset($t['class']) ? $t['class'] : '',
+                'type' => isset($t['type']) ? $t['type'] : '',
+                'context' => isset($t['file']) && isset($t['line']) ? $this->getContext($t['file'], $t['line']) : [], // get 5 lines before and after and main line
+                'args' => [],
+            ];
+
+            foreach ($t['args'] as $arg) {
+                if (is_array($arg)) {
+                    $traceArr['args'][] = json_encode($arg);
+                } else if (is_object($arg)) {
+                    $traceArr['args'][] = get_class($arg);
+                } else {
+                    $traceArr['args'][] = $arg;
+                }
+            }
+
+            $this->trace[] = $traceArr;
+        }
+    }
+
+    private function getContext($path, $targetLineNumber): array
+    {
+        if (!is_numeric($targetLineNumber)) {
+            return [];
+        }
+        $lineContext = [
+            'context_before' => [],
+            'context_line' => '',
+            'context_after' => [],
+        ];
+
+        $firstLineToRead = max(0, $targetLineNumber - 6);
+        $currentLineNumber = $firstLineToRead + 1;
+
+        $file = new \SplFileObject($path);
+        $file->seek($firstLineToRead);
+        while (!$file->eof()) {
+            $line = $file->current();
+            $line = rtrim($line, "\r\n");
+
+            if ($currentLineNumber == $targetLineNumber) {
+                $lineContext['context_line'] = $line;
+            } elseif ($currentLineNumber < $targetLineNumber) {
+                $lineContext['context_before'][] = $line;
+            } elseif ($currentLineNumber > $targetLineNumber) {
+                $lineContext['context_after'][] = $line;
+            }
+
+            $currentLineNumber++;
+
+            if ($currentLineNumber > $targetLineNumber + 5) {
+                break;
+            }
+
+            $file->next();
+        }
+
+        return $lineContext;
+    }
+
+    public function toArray(): array
+    {
+        return $this->trace;
+    }
+}

--- a/src/Error/Trace.php
+++ b/src/Error/Trace.php
@@ -19,13 +19,15 @@ class Trace
                 'args' => [],
             ];
 
-            foreach ($t['args'] as $arg) {
-                if (is_array($arg)) {
-                    $traceArr['args'][] = json_encode($arg);
-                } else if (is_object($arg)) {
-                    $traceArr['args'][] = get_class($arg);
-                } else {
-                    $traceArr['args'][] = $arg;
+            if (isset($t['args'])) {
+                foreach ($t['args'] as $arg) {
+                    if (is_array($arg)) {
+                        $traceArr['args'][] = json_encode($arg);
+                    } else if (is_object($arg)) {
+                        $traceArr['args'][] = get_class($arg);
+                    } else {
+                        $traceArr['args'][] = $arg;
+                    }
                 }
             }
 

--- a/src/Log.php
+++ b/src/Log.php
@@ -2,8 +2,6 @@
 
 namespace Tail;
 
-use Carbon\Carbon;
-
 class Log
 {
 
@@ -55,7 +53,7 @@ class Log
             'level' => $level,
             'message' => $message,
             'context' => $context,
-            'time' => Carbon::now()->toIso8601String(),
+            'time' => gmdate(DATE_ATOM),
         ];
 
         static::$logs[] = $log;

--- a/src/Meta/Cookies.php
+++ b/src/Meta/Cookies.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tail\Meta;
+
+class Cookies
+{
+
+    /** @var array Custom meta information */
+    protected $cookies = [];
+
+    public function __construct(array $cookies = [])
+    {
+        $this->cookies = $_COOKIE;
+        $this->merge($cookies);
+    }
+
+    /**
+     * Set custom cookie value
+     *
+     * @param string $key
+     * @param string $value
+     * @return self
+     */
+    public function set($key, $value): Cookies
+    {
+        $this->cookies[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Get cookie value
+     *
+     * @param string $key
+     * @return string|null
+     */
+    public function get(string $key)
+    {
+        if (array_key_exists($key, $this->cookies)) {
+            return $this->cookies[$key];
+        }
+
+        return null;
+    }
+
+    /**
+     * Replace all cookies with the provided key=>value array
+     *
+     * @param array $cookies
+     * @return self
+     */
+    public function replaceAll(array $cookies)
+    {
+        $this->cookies = $cookies;
+        return $this;
+    }
+
+    /**
+     * All custom set cookies
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->cookies;
+    }
+
+    /**
+     * Merge provided meta array. Any keys provided will overwrite existing metadata.
+     *
+     * @param array $cookies
+     * @return self
+     */
+    public function merge(array $cookies)
+    {
+        $this->cookies = array_merge($this->cookies, $cookies);
+        return $this;
+    }
+
+    /**
+     * Serialize meta information into an array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->all();
+    }
+}

--- a/src/Tail.php
+++ b/src/Tail.php
@@ -16,6 +16,9 @@ class Tail
     /** @var bool */
     protected static $logsEnabled;
 
+    /** @var bool */
+    protected static $errorsEnabled;
+
     /** @var string */
     protected static $service;
 
@@ -33,6 +36,7 @@ class Tail
         static::$meta = new TailMeta();
         static::$apmEnabled = static::shouldEnableApm($config);
         static::$logsEnabled = static::shouldEnableLogs($config);
+        static::$errorsEnabled = static::shouldEnableErrors($config);
         static::$meta->service()->setName(static::serviceName($config));
         static::$meta->service()->setEnvironment(static::environmentName($config));
 
@@ -82,6 +86,21 @@ class Tail
 
         if (array_key_exists('logs_enabled', $config)) {
             $enable = $config['logs_enabled'];
+        }
+
+        return $enable;
+    }
+
+    protected static function shouldEnableErrors(array $config)
+    {
+        $enable = true;
+
+        if (Env::get('TAIL_ERRORS_ENABLED') !== null) {
+            $enable = Env::get('TAIL_ERRORS_ENABLED');
+        }
+
+        if (array_key_exists('errors_enabled', $config)) {
+            $enable = $config['errors_enabled'];
         }
 
         return $enable;
@@ -140,6 +159,22 @@ class Tail
     }
 
     /**
+     * Set APM to be disabled
+     */
+    public static function disableApm()
+    {
+        static::$apmEnabled = false;
+    }
+
+    /**
+     * Set APM to be enabled
+     */
+    public static function enableApm()
+    {
+        static::$apmEnabled = true;
+    }
+
+    /**
      * @return bool
      */
     public static function logsEnabled()
@@ -168,19 +203,31 @@ class Tail
     }
 
     /**
-     * Set APM to be disabled
+     * @return bool
      */
-    public static function disableApm()
+    public static function errorsEnabled()
     {
-        static::$apmEnabled = false;
+        if (!static::$initialized) {
+            static::init();
+        }
+
+        return static::$errorsEnabled;
     }
 
     /**
-     * Set APM to be enabled
+     * Set errors to be disabled
      */
-    public static function enableApm()
+    public static function disableErrors()
     {
-        static::$apmEnabled = true;
+        static::$errorsEnabled = false;
+    }
+
+    /**
+     * Set errors to be enabled
+     */
+    public static function enableErrors()
+    {
+        static::$errorsEnabled = true;
     }
 
     /**

--- a/src/Tail.php
+++ b/src/Tail.php
@@ -132,6 +132,7 @@ class Tail
     {
         Apm::finish();
         Log::flush();
+        Error::send();
     }
 
     /**

--- a/src/TailMeta.php
+++ b/src/TailMeta.php
@@ -2,11 +2,12 @@
 
 namespace Tail;
 
+use Tail\Meta\Agent;
+use Tail\Meta\Cookies;
+use Tail\Meta\Service;
+use Tail\Meta\System;
 use Tail\Meta\Tags;
 use Tail\Meta\User;
-use Tail\Meta\Agent;
-use Tail\Meta\System;
-use Tail\Meta\Service;
 
 class TailMeta
 {
@@ -23,6 +24,9 @@ class TailMeta
     /** @var Tags Custom metadata */
     protected $tags;
 
+    /** @var Cookies Custom metadata */
+    protected $cookies;
+
     /** @var User User metadata */
     protected $user;
 
@@ -32,6 +36,7 @@ class TailMeta
         $this->service = new Service();
         $this->system = new System();
         $this->tags = new Tags();
+        $this->cookies = new Cookies();
         $this->user = new User();
     }
 
@@ -40,7 +45,7 @@ class TailMeta
      *
      * @return Agent
      */
-    public function agent()
+    public function agent(): Agent
     {
         return $this->agent;
     }
@@ -50,7 +55,7 @@ class TailMeta
      *
      * @return Service
      */
-    public function service()
+    public function service(): Service
     {
         return $this->service;
     }
@@ -60,7 +65,7 @@ class TailMeta
      *
      * @return System
      */
-    public function system()
+    public function system(): System
     {
         return $this->system;
     }
@@ -70,9 +75,19 @@ class TailMeta
      *
      * @return Tags
      */
-    public function tags()
+    public function tags(): Tags
     {
         return $this->tags;
+    }
+
+    /**
+     * Get/set custom metadata
+     *
+     * @return Cookies
+     */
+    public function cookies(): Cookies
+    {
+        return $this->cookies;
     }
 
     /**
@@ -80,11 +95,10 @@ class TailMeta
      *
      * @return User
      */
-    public function user()
+    public function user(): User
     {
         return $this->user;
     }
-
 
     public function toArray()
     {
@@ -94,6 +108,7 @@ class TailMeta
             'system' => $this->system->toArray(),
             'tags' => $this->tags->toArray(),
             'user' => $this->user->toArray(),
+            'cookies' => $this->cookies->toArray(),
         ];
     }
 }

--- a/tests/Apm/TransactionTest.php
+++ b/tests/Apm/TransactionTest.php
@@ -4,9 +4,9 @@ namespace Tests\Apm;
 
 use Mockery;
 use Tail\Apm\Span;
-use Tests\TestCase;
-use Tail\Apm\Transaction;
 use Tail\Apm\Support\Timestamp;
+use Tail\Apm\Transaction;
+use Tests\TestCase;
 
 class TransactionTest extends TestCase
 {
@@ -27,62 +27,63 @@ class TransactionTest extends TestCase
     public function test_create_from_array()
     {
         $transaction = Transaction::createFromArray($data = [
-           'trace' => [
-               'id' => 'custom-transaction-id',
-               'type' => Transaction::TYPE_JOB,
-               'name' => 'custom-name',
-               'start_time' => 123.1,
-               'end_time' => 456.2,
-               'duration' => 333.1,
-           ],
-           'agent' => [
-               'name' => 'custom-agent-name',
-               'type' => 'custom-agent-type',
-               'version' => 'custom-agent-version',
-           ],
-           'http' => [
-               'method' => 'CUSTOM-HTTP-METHOD',
-               'url' => 'custom-url',
-               'url_params' => ['foo' => 'bar'],
-               'request_headers' => ['auth' => '123'],
-               'response_headers' => ['type' => 'json'],
-               'response_status' => 200,
-           ],
-           'service' => [
-               'name' => 'custom-service',
-               'environment' => 'custom-env',
-           ],
-           'system' => [
-               'hostname' => 'custom-hostname',
-           ],
-           'tags' => [
-               'custom' => 'tag',
-           ],
-           'user' => [
-               'id' => 'custom-id',
-               'email' => 'custom-email',
-           ],
-           'spans' => [
-               [
-                   'trace' => [
-                       'type' => 'some-type',
-                       'name' => 'some-span',
-                       'id' => 'span-id',
-                       'parent_id' => 'span-parent-id',
-                       'transaction_id' => 'custom-transaction-id',
-                       'start_time' => 123.4,
-                       'end_time' => 234.5,
-                       'duration' => 111.1,
-                   ],
-                   'database' => [
-                       'name' => 'custom-db-name',
-                       'query' => 'custom-db-query',
-                   ],
-                   'tags' => [
-                       'span-foo' => 'span-bar',
-                   ],
-               ]
-           ],
+            'trace' => [
+                'id' => 'custom-transaction-id',
+                'type' => Transaction::TYPE_JOB,
+                'name' => 'custom-name',
+                'start_time' => 123.1,
+                'end_time' => 456.2,
+                'duration' => 333.1,
+            ],
+            'agent' => [
+                'name' => 'custom-agent-name',
+                'type' => 'custom-agent-type',
+                'version' => 'custom-agent-version',
+            ],
+            'http' => [
+                'method' => 'CUSTOM-HTTP-METHOD',
+                'url' => 'custom-url',
+                'url_params' => ['foo' => 'bar'],
+                'request_headers' => ['auth' => '123'],
+                'response_headers' => ['type' => 'json'],
+                'response_status' => 200,
+                'remote_address' => '127.0.0.1',
+            ],
+            'service' => [
+                'name' => 'custom-service',
+                'environment' => 'custom-env',
+            ],
+            'system' => [
+                'hostname' => 'custom-hostname',
+            ],
+            'tags' => [
+                'custom' => 'tag',
+            ],
+            'user' => [
+                'id' => 'custom-id',
+                'email' => 'custom-email',
+            ],
+            'spans' => [
+                [
+                    'trace' => [
+                        'type' => 'some-type',
+                        'name' => 'some-span',
+                        'id' => 'span-id',
+                        'parent_id' => 'span-parent-id',
+                        'transaction_id' => 'custom-transaction-id',
+                        'start_time' => 123.4,
+                        'end_time' => 234.5,
+                        'duration' => 111.1,
+                    ],
+                    'database' => [
+                        'name' => 'custom-db-name',
+                        'query' => 'custom-db-query',
+                    ],
+                    'tags' => [
+                        'span-foo' => 'span-bar',
+                    ],
+                ],
+            ],
         ]);
 
         $this->assertSame($data, $transaction->toArray());

--- a/tests/Error/TraceTest.php
+++ b/tests/Error/TraceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Error;
+
+use Tail\Error\Trace;
+use Tests\TestCase;
+
+class TraceTest extends TestCase
+{
+    public function test_trace()
+    {
+        // Arrange
+        $exceptionTrace = [
+            'file' => __FILE__,
+            'function' => 'test_trace',
+            'class' => get_class($this),
+            'type' => '->',
+            'line' => __LINE__,
+            'args' => [[], 24],
+        ];
+
+        // Act
+        $trace = new Trace([$exceptionTrace]);
+        $firstTrace = $trace->toArray()[0];
+
+        // Assert
+        $this->assertSame($exceptionTrace['file'], $firstTrace['file']);
+        $this->assertSame($exceptionTrace['line'], $firstTrace['line']);
+        $this->assertSame($exceptionTrace['class'], $firstTrace['class']);
+        $this->assertSame($exceptionTrace['type'], $firstTrace['type']);
+        $this->assertSame($exceptionTrace['function'], $firstTrace['function']);
+        $this->assertSame(['[]', 24], $firstTrace['args']);
+
+        $this->assertCount(5, $firstTrace['context']['context_before']);
+        $this->assertCount(5, $firstTrace['context']['context_after']);
+
+        $this->assertSame("            'type' => '->',", $firstTrace['context']['context_before'][4]);
+        $this->assertSame("            'line' => __LINE__,", $firstTrace['context']['context_line']);
+        $this->assertSame("            'args' => [[], 24],", $firstTrace['context']['context_after'][0]);
+    }
+}

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests;
+
+use Exception;
+use Mockery;
+use Tail\Client;
+use Tail\Error;
+use Tail\Meta\Http;
+use Tail\Tail;
+
+class ErrorTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        Tail::$initialized = false;
+    }
+
+    public function test_send_error()
+    {
+        // Arrange
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('sendError')
+            ->withAnyArgs()->once();
+        Tail::init(['errors_enabled' => true]);
+        Tail::setClient($client);
+
+        // Act
+        Error::capture(new Exception());
+    }
+
+    public function test_error()
+    {
+        // Arrange
+        Tail::init(['errors_enabled' => false]);
+
+        // Act
+        Error::capture(new Exception('Your cars extended warrenty is about to expire'));
+
+        // Assert
+        $this->assertSame(Error::$error['exception'], Exception::class);
+        $this->assertSame(Error::$error['message'], 'Your cars extended warrenty is about to expire');
+        $this->assertSame(Error::$error['file'], __FILE__);
+        $this->assertIsNumeric(Error::$error['line']);
+        $this->assertSame(Error::$error['runtime'], 'php');
+        $this->assertSame(Error::$error['runtime_version'], phpversion());
+        $this->assertEqualsWithDelta(strtotime(Error::$error['time']), time(), 1);
+        $this->assertSame(Error::$error['http'], (new Http())->toArray());
+        $this->assertSame(Error::$error['cookies'], $_COOKIE);
+        $this->assertIsArray(Error::$error['trace']);
+    }
+}

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -6,7 +6,6 @@ use Exception;
 use Mockery;
 use Tail\Client;
 use Tail\Error;
-use Tail\Meta\Http;
 use Tail\Tail;
 
 class ErrorTest extends TestCase
@@ -15,39 +14,88 @@ class ErrorTest extends TestCase
     {
         parent::setUp();
         Tail::$initialized = false;
+        Error::$errors = [];
     }
 
     public function test_send_error()
     {
         // Arrange
         $client = Mockery::mock(Client::class);
-        $client->shouldReceive('sendError')
-            ->withAnyArgs()->once();
+        $client->shouldReceive('sendErrors')->once();
         Tail::init(['errors_enabled' => true]);
         Tail::setClient($client);
 
         // Act
         Error::capture(new Exception());
+        Error::send();
+
+        // Assert
+        $this->assertCount(0, Error::$errors);
     }
 
-    public function test_error()
+    public function test_error_data()
     {
-        // Arrange
-        Tail::init(['errors_enabled' => false]);
-
         // Act
         Error::capture(new Exception('Your cars extended warrenty is about to expire'));
 
         // Assert
-        $this->assertSame(Error::$error['exception'], Exception::class);
-        $this->assertSame(Error::$error['message'], 'Your cars extended warrenty is about to expire');
-        $this->assertSame(Error::$error['file'], __FILE__);
-        $this->assertIsNumeric(Error::$error['line']);
-        $this->assertSame(Error::$error['runtime'], 'php');
-        $this->assertSame(Error::$error['runtime_version'], phpversion());
-        $this->assertEqualsWithDelta(strtotime(Error::$error['time']), time(), 1);
-        $this->assertSame(Error::$error['http'], (new Http())->toArray());
-        $this->assertSame(Error::$error['cookies'], $_COOKIE);
-        $this->assertIsArray(Error::$error['trace']);
+        $firstError = Error::$errors[0];
+        $this->assertSame($firstError['exception'], Exception::class);
+        $this->assertSame($firstError['message'], 'Your cars extended warrenty is about to expire');
+        $this->assertSame($firstError['file'], __FILE__);
+        $this->assertIsNumeric($firstError['line']);
+        $this->assertSame($firstError['runtime'], 'php');
+        $this->assertSame($firstError['runtime_version'], phpversion());
+        $this->assertEqualsWithDelta(strtotime($firstError['time']), time(), 1);
+        $this->assertIsArray($firstError['trace']);
+    }
+
+    public function test_send_errors_only_sends_errors_if_present()
+    {
+        // Arrange
+        Tail::init();
+        $client = Mockery::mock(Client::class);
+        Tail::setClient($client);
+
+        // Act
+        Error::send();
+
+        // Assert
+        $client->shouldNotReceive('sendErrors');
+    }
+
+    public function test_send_errors_doesnt_send_errors_if_error_reporting_is_disabled()
+    {
+        // Arrange
+        Error::capture(new Exception());
+        Tail::init(['errors_enabled' => false]);
+        $client = Mockery::mock(Client::class);
+        Tail::setClient($client);
+
+        // Act
+        Error::send();
+
+        // Assert
+        $client->shouldNotReceive('sendErrors');
+    }
+
+    public function test_send_errors_attaches_metadata_to_each_record()
+    {
+        // Arrange / Assert
+        Error::capture(new Exception());
+        Error::capture(new Exception());
+
+        $expected = array_map(function ($error) {
+            return array_merge($error, Tail::meta()->toArray());
+        }, Error::$errors);
+
+        Tail::init(['errors_enabled' => true]);
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('sendErrors')->with($expected)->once();
+
+        Tail::setClient($client);
+
+        // Act
+        Error::send();
     }
 }

--- a/tests/LogTest.php
+++ b/tests/LogTest.php
@@ -3,10 +3,9 @@
 namespace Tests;
 
 use Mockery;
+use Tail\Client;
 use Tail\Log;
 use Tail\Tail;
-use Tail\Client;
-use Carbon\Carbon;
 
 class LogTest extends TestCase
 {
@@ -24,19 +23,19 @@ class LogTest extends TestCase
         Log::log('debug', 'My debug message', ['number' => 2]);
 
         $this->assertCount(2, Log::$logs);
-        $expectedTime = Carbon::now()->timestamp;
+        $expectedTime = time();
 
         $log1 = Log::$logs[0];
         $this->assertSame('info', $log1['level']);
         $this->assertSame('My info message', $log1['message']);
         $this->assertSame(['number' => 1], $log1['context']);
-        $this->assertEqualsWithDelta($expectedTime, Carbon::parse($log1['time'])->timestamp, 1);
+        $this->assertEqualsWithDelta($expectedTime, strtotime($log1['time']), 1);
 
         $log2 = Log::$logs[1];
         $this->assertSame('debug', $log2['level']);
         $this->assertSame('My debug message', $log2['message']);
         $this->assertSame(['number' => 2], $log2['context']);
-        $this->assertEqualsWithDelta($expectedTime, Carbon::parse($log2['time'])->timestamp, 1);
+        $this->assertEqualsWithDelta($expectedTime, strtotime($log2['time']), 1);
     }
 
     public function test_flush_logs()

--- a/tests/Meta/HttpTest.php
+++ b/tests/Meta/HttpTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Meta;
 
-use Tests\TestCase;
 use Tail\Meta\Http;
+use Tests\TestCase;
 
 class HttpTest extends TestCase
 {
@@ -20,15 +20,48 @@ class HttpTest extends TestCase
     {
         unset($_SERVER['REQUEST_METHOD']);
         unset($_SERVER['REQUEST_URI']);
+        unset($_SERVER['REMOTE_ADDR']);
         $http = new Http();
         $this->assertEmpty($http->method());
         $this->assertEmpty($http->url());
 
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SERVER['REQUEST_URI'] = '/foo/bar';
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        $_SERVER['HTTP_HOST'] = 'localhost:9001';
+        $_SERVER['HTTP_CONNECTION'] = 'keep-alive';
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh;';
+        $_SERVER['HTTP_CACHE_CONTROL'] = 'max-age=0';
+        $_SERVER['HTTP_SEC_CH_UA'] = '\"Chromium\";v=\"91\"';
+        $_SERVER['HTTP_SEC_CH_UA_MOBILE'] = '?0';
+        $_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] = '1';
+        $_SERVER['HTTP_ACCEPT'] = 'text/html';
+        $_SERVER['HTTP_SEC_FETCH_SITE'] = 'none';
+        $_SERVER['HTTP_SEC_FETCH_MODE'] = 'navigate';
+        $_SERVER['HTTP_SEC_FETCH_USER'] = '?1';
+        $_SERVER['HTTP_SEC_FETCH_DEST'] = 'document';
+        $_SERVER['HTTP_ACCEPT_ENCODING'] = 'gzip, deflate, br';
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en';
+
         $http = new Http();
         $this->assertSame('POST', $http->method());
         $this->assertSame('/foo/bar', $http->url());
+        $this->assertSame('127.0.0.1', $http->remoteAddress());
+        $this->assertSame('localhost:9001', $http->requestHeaders()['host']);
+        $this->assertSame('keep-alive', $http->requestHeaders()['connection']);
+        $this->assertSame('Mozilla/5.0 (Macintosh;', $http->requestHeaders()['user_agent']);
+        $this->assertSame('max-age=0', $http->requestHeaders()['cache_control']);
+        $this->assertSame('\"Chromium\";v=\"91\"', $http->requestHeaders()['sec_ch_ua']);
+        $this->assertSame('?0', $http->requestHeaders()['sec_ch_ua_mobile']);
+        $this->assertSame('1', $http->requestHeaders()['upgrade_insecure_requests']);
+        $this->assertSame('text/html', $http->requestHeaders()['accept']);
+        $this->assertSame('none', $http->requestHeaders()['sec_fetch_site']);
+        $this->assertSame('navigate', $http->requestHeaders()['sec_fetch_mode']);
+        $this->assertSame('?1', $http->requestHeaders()['sec_fetch_user']);
+        $this->assertSame('document', $http->requestHeaders()['sec_fetch_dest']);
+        $this->assertSame('gzip, deflate, br', $http->requestHeaders()['accept_encoding']);
+        $this->assertSame('en-US,en', $http->requestHeaders()['accept_language']);
     }
 
     public function test_fill_from_array()
@@ -37,6 +70,7 @@ class HttpTest extends TestCase
         $http->fillFromArray([
             'method' => 'custom-method',
             'url' => 'custom-url',
+            'remote_address' => '127.0.0.1',
             'url_params' => ['custom' => 'params'],
             'request_headers' => ['custom' => 'request-headers'],
             'response_headers' => ['custom' => 'response-headers'],
@@ -93,11 +127,19 @@ class HttpTest extends TestCase
         $this->assertSame(200, $this->http->responseStatus());
     }
 
+    public function test_set_remote_address()
+    {
+        $result = $this->http->setRemoteAddress('127.0.0.1');
+        $this->assertSame($this->http, $result);
+        $this->assertSame('127.0.0.1', $this->http->remoteAddress());
+    }
+
     public function test_output_to_array()
     {
         $http = new Http();
         $http->setMethod('get');
         $http->setUrl('/foo');
+        $http->setRemoteAddress('127.0.0.1');
         $http->setUrlParams(['foo' => 'bar']);
         $http->setRequestHeaders(['authorization' => 'bearer123']);
         $http->setResponseHeaders(['content-type' => 'application/json']);
@@ -110,6 +152,7 @@ class HttpTest extends TestCase
             'request_headers' => ['authorization' => 'bearer123'],
             'response_headers' => ['content-type' => 'application/json'],
             'response_status' => 200,
+            'remote_address' => '127.0.0.1',
         ];
 
         $this->assertSame($expect, $http->toArray());

--- a/tests/TailMetaTest.php
+++ b/tests/TailMetaTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use Tests\TestCase;
 use Tail\TailMeta;
+use Tests\TestCase;
 
 class LogMetaTest extends TestCase
 {
@@ -17,6 +17,7 @@ class LogMetaTest extends TestCase
             'system' => $meta->system()->toArray(),
             'tags' => $meta->tags()->toArray(),
             'user' => $meta->user()->toArray(),
+            'cookies' => $meta->cookies()->toArray(),
         ];
 
         $this->assertSame($expect, $meta->toArray());


### PR DESCRIPTION
1. I added error reporting capabilities. To catch an error use:

```php
Error::capture(new Exception());
```

2. I've added the gathering of server headers to the `Meta/Http` class `__construct()` method so it's automatic.


3. I've also replaced all Carbon functionality with base php. I figured we would want to keep as few dependencies as possible to avoid any kind of conflict people might have with our repo.